### PR TITLE
FOSFAB-176: Format financial item lines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,14 +6,14 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
 
     services:
       mysql:
-        image: mariadb:10.3.10
+        image: mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.89 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.91 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.39.1
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2
@@ -49,4 +49,4 @@ jobs:
 
       - name: Run phpunit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/io.compuco.financeexportformats
-        run: phpunit5
+        run: phpunit9

--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -1,0 +1,176 @@
+<?php
+
+class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
+
+  const TYPE_LABEL = 'Type',
+        ACCOUNT_REFERENCE_LABEL = 'Account Reference',
+        NOMINAL_AC_REF_LABEL = 'Nominal A/C Ref',
+        DEPARTMENT_CODE_LABEL = 'Department Code',
+        DATE_LABEL = 'Date',
+        REFERENCE_LABEL = 'Reference',
+        DETAILS_LABEL = 'Details',
+        NET_AMOUNT_LABEL = 'Net Amount',
+        TAX_CODE_LABEL = 'Tax Code',
+        TAX_AMOUNT_LABEL = 'Tax Amount',
+        EXCHANGE_RATE_LABEL = 'Exchange Rate',
+        EXTRA_REFERENCE = 'Extra Reference',
+        USER_NAME_LABEL = 'User Name',
+        PROJECT_REFN_LABEL = 'Project Refn',
+        COST_CODE_REFN_LABEL = 'Cost Code Refn';
+
+  private $financialTypeTaxCodeMap;
+  private $invoicePrefixValue;
+
+  public function __construct() {
+    $this->invoicePrefixValue = Civi::settings()->get('contribution_invoice_settings');
+    $this->financialTypeTaxCodeMap = [];
+  }
+
+  /**
+   *
+   * @param int $batchId
+   *
+   * @return CRM_Core_DAO
+   */
+  public static function runExportQuery($batchId) {
+    $sql = "SELECT
+      c.id as contribution_id,
+      con.display_name as contact_display_name,
+      c.invoice_number,
+      ft.id as financial_trxn_id,
+      ft.trxn_date,
+      ft.is_payment,
+      ft.total_amount AS debit_total_amount,
+      ft.trxn_id AS trxn_id,
+      CASE
+        WHEN efti.entity_id IS NOT NULL
+        THEN efti.amount
+        ELSE eftc.amount
+      END AS amount,
+      fa_from.account_type_code AS credit_account_type_code,
+      fa_from.accounting_code AS credit_account,
+      fa_from.name AS credit_account_name,
+      fac.account_type_code AS from_credit_account_type_code,
+      fac.accounting_code AS from_credit_account,
+      fac.name AS from_credit_account_name,
+      fi.amount as net_amount,
+      eftc.id as civicrm_entity_financial_trxn_id,
+      li.label as item_description,
+      li.tax_amount as line_item_tax_amount,
+      li.financial_type_id as line_item_financial_type_id
+    FROM civicrm_entity_batch eb
+             LEFT JOIN civicrm_financial_trxn ft ON (eb.entity_id = ft.id AND eb.entity_table = 'civicrm_financial_trxn')
+             LEFT JOIN civicrm_financial_account fa_from ON fa_from.id = ft.from_financial_account_id
+             LEFT JOIN civicrm_entity_financial_trxn eftc ON (eftc.financial_trxn_id  = ft.id AND eftc.entity_table = 'civicrm_contribution')
+             LEFT JOIN civicrm_contribution c ON c.id = eftc.entity_id
+             LEFT JOIN civicrm_contact con on con.id = c.contact_id
+             LEFT JOIN civicrm_entity_financial_trxn efti ON (efti.financial_trxn_id  = ft.id AND efti.entity_table = 'civicrm_financial_item')
+             LEFT JOIN civicrm_financial_item fi ON fi.id = efti.entity_id
+             LEFT JOIN civicrm_line_item li ON (li.id = fi.entity_id AND fi.entity_table = 'civicrm_line_item')
+             LEFT JOIN civicrm_financial_account fac ON fac.id = fi.financial_account_id
+    WHERE eb.batch_id = ( %1 )";
+
+    CRM_Utils_Hook::batchQuery($sql);
+
+    $params = [1 => [$batchId, 'Integer']];
+    $dao = CRM_Core_DAO::executeQuery($sql, $params);
+
+    return $dao;
+  }
+
+  /**
+   * @param $exportResultDao
+   *
+   * @return array
+   */
+  public function formatDataRows($exportResultDao) {
+    $financialItems = $queryResults = [];
+    while ($exportResultDao->fetch()) {
+      $item = [
+        self::TYPE_LABEL => NULL,
+        self::ACCOUNT_REFERENCE_LABEL => 'CiviCRM',
+        self::NOMINAL_AC_REF_LABEL => NULL,
+        self::DEPARTMENT_CODE_LABEL => NULL,
+        self::DATE_LABEL => CRM_Utils_Date::customFormat($exportResultDao->trxn_date, '%d/%m/%Y'),
+        self::REFERENCE_LABEL => $exportResultDao->invoice_number,
+        self::DETAILS_LABEL => NULL,
+        self::NET_AMOUNT_LABEL => NULL,
+        self::TAX_CODE_LABEL => NULL,
+        self::TAX_AMOUNT_LABEL => $exportResultDao->line_item_tax_amount,
+        self::EXCHANGE_RATE_LABEL => NULL,
+        self::EXTRA_REFERENCE => NULL,
+        self::USER_NAME_LABEL => NULL,
+        self::PROJECT_REFN_LABEL => NULL,
+        self::COST_CODE_REFN_LABEL => NULL,
+      ];
+
+      if ($exportResultDao->is_payment == 0) {
+        $formattedItem = $this->formatFinancialItemLines($item, $exportResultDao);
+        if (is_null($formattedItem)) {
+          continue;
+        }
+
+        $financialItems[] = $formattedItem;
+      }
+
+      end($financialItems);
+      $queryResults[] = get_object_vars($exportResultDao);
+    }
+
+    return [$queryResults, $financialItems];
+  }
+
+  private function formatFinancialItemLines(array $item, $exportResultDao) {
+    $creditAccount = $exportResultDao->credit_account;
+    if (!is_null($creditAccount)) {
+      return NULL;
+    }
+
+    if ($exportResultDao->amount >= 0) {
+      $item[self::TYPE_LABEL] = 'SI';
+    }
+    else {
+      $item[self::TYPE_LABEL] = 'SC';
+    }
+
+    $item[self::NOMINAL_AC_REF_LABEL] = $exportResultDao->from_credit_account;
+    $item[self::DETAILS_LABEL] = $exportResultDao->contact_display_name . ' - ' . $exportResultDao->item_description;
+    $item[self::NET_AMOUNT_LABEL] = $exportResultDao->net_amount;
+    $item[self::EXTRA_REFERENCE] = $exportResultDao->civicrm_entity_financial_trxn_id;
+    if (!is_null($exportResultDao->line_item_tax_amount)) {
+      $item[self::TAX_CODE_LABEL] = $this->getFinancialIemLinesTaxCodeByFinancialID($exportResultDao->line_item_financial_type_id);
+    }
+    return $item;
+  }
+
+  private function getFinancialIemLinesTaxCodeByFinancialID($financialTypeID) {
+    if (isset($this->financialTypeTaxCodeMap[$financialTypeID])) {
+      return $this->financialTypeTaxCodeMap[$financialTypeID];
+    }
+
+    $sql = "SELECT
+        efa.id,
+        fa.account_type_code
+    FROM civicrm_entity_financial_account efa
+        INNER JOIN civicrm_financial_account fa ON fa.id = efa.financial_account_id
+    WHERE
+        efa.entity_id = %1 AND efa.entity_table = 'civicrm_financial_type' AND fa.is_tax = 1";
+
+    $params = [1 => [$financialTypeID, 'Integer']];
+    $dao = CRM_Core_DAO::executeQuery($sql, $params);
+
+    $taxCode = 'T2';
+    while ($dao->fetch()) {
+      $accountTypeCode = $dao->account_type_code;
+      if (!is_null($accountTypeCode)) {
+        $taxCode = $accountTypeCode;
+      }
+    }
+
+    // Cache tax code to the financial type.
+    $this->financialTypeTaxCodeMap[$financialTypeID] = $taxCode;
+
+    return $taxCode;
+  }
+
+}

--- a/CRM/Financial/BAO/ExportFormat/Sage50CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/Sage50CSV.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Formats batch rows according to Sage50 CSV format.
+ *
+ */
+class CRM_Financial_BAO_ExportFormat_Sage50CSV extends CRM_Financial_BAO_ExportFormat {
+
+  /**
+   * @param array $exportParams
+   */
+  public function export($exportParams) {
+    $export = parent::export($exportParams);
+
+    // Save the file in the public directory.
+    $fileName = $this->putFile($export);
+
+    $this->output($fileName);
+  }
+
+  /**
+   * @param $export
+   *
+   * @return string
+   */
+  public function putFile($export) {
+    $config = CRM_Core_Config::singleton();
+    $fileName = $config->uploadDir . 'Financial_Transactions_' . $this->_batchIds . '_' . date('YmdHis') . '.' . $this->getFileExtension();
+    $this->_downloadFile[] = $config->customFileUploadDir . CRM_Utils_File::cleanFileName(basename($fileName));
+    $out = fopen($fileName, 'w');
+    if (!empty($export['headers'])) {
+      fputcsv($out, $export['headers']);
+    }
+    unset($export['headers']);
+    if (!empty($export)) {
+      foreach ($export as $fields) {
+        fputcsv($out, $fields);
+      }
+      fclose($out);
+    }
+    return $fileName;
+  }
+
+  /**
+   * @return string
+   */
+  public function getFileExtension() {
+    return 'csv';
+  }
+
+  /**
+   * @param int $batchId
+   *
+   * @return Object
+   */
+  public function generateExportQuery($batchId) {
+    return CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider::runExportQuery($batchId);
+  }
+
+  /**
+   * Generates CSV array for export.
+   *
+   * @param array $export
+   */
+  public function makeExport($export) {
+    foreach ($export as $batchId => $exportResultDao) {
+      $financialItems = [];
+      $this->_batchIds = $batchId;
+
+      $dataProvider = new CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider();
+      list($queryResults, $financialItems) = $dataProvider->formatDataRows($exportResultDao);
+
+      CRM_Utils_Hook::batchItems($queryResults, $financialItems);
+
+      $financialItems['headers'] = $this->formatHeaders($financialItems);
+      $this->export($financialItems);
+    }
+
+    parent::initiateDownload();
+  }
+
+  /**
+   * Formats table headers.
+   *
+   * @param array $values
+   * @return array
+   */
+  public function formatHeaders($values) {
+    $arrayKeys = array_keys($values);
+    $headers = [];
+    if (!empty($arrayKeys)) {
+      foreach ($values[$arrayKeys[0]] as $title => $value) {
+        $headers[] = $title;
+      }
+    }
+    return $headers;
+  }
+
+}

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
   <version>1.0.0-alpha</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.39</ver>
+    <ver>5.51.3</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -3,7 +3,7 @@
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
-abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
 
   public function setUpHeadless() {
     return \Civi\Test::headless()

--- a/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
@@ -1,0 +1,258 @@
+<?php
+
+use CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider as Sage50CSVProvider;
+
+/**
+ * @group headless
+ */
+class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends BaseHeadlessTest {
+
+  public function setup() {
+    $this->setContributionSettings();
+  }
+
+  public function testFinancialIemLinesWithoutConfigureVAT() {
+    $contributionData = $this->mockContributionInBatch(100);
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+    $row = $rows[0];
+
+    $contribution = $this->getContributionByID($contributionData['contribution_id']);
+    $lineItem = $this->getLineItemByContributionID($contribution['id']);
+
+    $this->assertEquals('SI', $row[Sage50CSVProvider::TYPE_LABEL]);
+    $this->assertEquals('CiviCRM', $row[Sage50CSVProvider::ACCOUNT_REFERENCE_LABEL]);
+    $this->assertEquals(4200, $row[Sage50CSVProvider::NOMINAL_AC_REF_LABEL]);
+    $this->assertEquals(NULL, $row[Sage50CSVProvider::DEPARTMENT_CODE_LABEL]);
+    $this->assertEquals('01/06/2023', $row[Sage50CSVProvider::DATE_LABEL]);
+    $this->assertEquals($contribution['invoice_number'], $row[Sage50CSVProvider::REFERENCE_LABEL]);
+    $this->assertEquals($contribution['display_name'] . ' - ' . $lineItem['label'], $row[Sage50CSVProvider::DETAILS_LABEL]);
+    $this->assertEquals(100, $row[Sage50CSVProvider::NET_AMOUNT_LABEL]);
+    $this->assertEquals('T2', $row[Sage50CSVProvider::TAX_CODE_LABEL]);
+    $this->assertEquals(0, $row[Sage50CSVProvider::TAX_AMOUNT_LABEL]);
+  }
+
+  public function testFinancialItemLinesWithZeroRatedVAT() {
+    $this->mockSalesTaxFinancialAccount(0);
+    $contributionData = $this->mockContributionInBatch(100);
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+    $row = $rows[0];
+    $this->assertEquals(0, $row[Sage50CSVProvider::TAX_AMOUNT_LABEL]);
+  }
+
+  public function testFinancialIemLinesWithVAT() {
+    $this->mockSalesTaxFinancialAccount();
+    $contributionData = $this->mockContributionInBatch(120);
+
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+    $row = $rows[0];
+    $this->assertEquals(20, $row[Sage50CSVProvider::TAX_AMOUNT_LABEL]);
+  }
+
+  public function testFinancialIemLinesNegativeChangeOnAContribution() {
+    $contributionData = $this->mockContributionInBatch(100);
+    $this->mockNonPaymentNegativeBalanceTxrn($contributionData['contribution_id'], $contributionData['batch_id'], 50);
+
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+
+    $row = $rows[0];
+    $this->assertEquals('SI', $row[Sage50CSVProvider::TYPE_LABEL]);
+
+    $row = $rows[1];
+    $this->assertEquals('SC', $row[Sage50CSVProvider::TYPE_LABEL]);
+  }
+
+  /**
+   * Sets CiviContribute settings.
+   */
+  private function setContributionSettings() {
+    Civi::settings()->set('always_post_to_accounts_receivable', TRUE);
+    Civi::settings()->set('invoicing', TRUE);
+    Civi::settings()->set('invoice_prefix', "INV_");
+    Civi::settings()->set('tax_term', "Sales Tax");
+  }
+
+  /**
+   * Mocks Negative Balance Transaction for non payment transaction.
+   *
+   * Create a negative on balance on contribution and financial transaction.
+   * This method only provide the records that batch export could handle
+   * The sage50 type e.g. SI or SC. It does not provide completed entities in
+   * CiviCRM financial transactions.
+   */
+  private function mockNonPaymentNegativeBalanceTxrn($contributionID, $batchID, $amount) {
+    $contribution = $this->getContributionByID($contributionID);
+    $balanceAmount = $contribution['total_amount'] - $amount;
+    civicrm_api3('contribution', 'create', [
+      'id' => $contribution['contribution_id'],
+      'total_amount' => $balanceAmount,
+    ]);
+
+    $toFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($contribution['financial_type_id'], 'Accounts Receivable Account is');
+    $adjustedTrxnValues = array(
+      'from_financial_account_id' => NULL,
+      'to_financial_account_id' => $toFinancialAccount,
+      'total_amount' => -$balanceAmount,
+      'net_amount' => -$balanceAmount,
+      'payment_instrument_id' => $contribution['payment_instrument_id'],
+      'contribution_id' => $contribution['id'],
+      'trxn_date' => date('YmdHis'),
+      'currency' => $contribution['currency'],
+      'is_payment' => FALSE,
+    );
+    $adjustedTrxn = CRM_Core_BAO_FinancialTrxn::create($adjustedTrxnValues);
+
+    civicrm_api3('EntityBatch', 'create', [
+      'entity_id' => $adjustedTrxn->id,
+      'batch_id' => $batchID,
+      'entity_table' => 'civicrm_financial_trxn',
+    ]);
+  }
+
+  /**
+   * Creates financial transaction including payments and
+   * add transactions to entity batch.
+   *
+   * @return array
+   */
+  private function mockContributionInBatch($amount) {
+    $contact = civicrm_api3('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'John',
+      'last_name' => 'Smith',
+    ]);
+    $contactId = $contact['id'];
+
+    $order = civicrm_api3('Order', 'create', [
+      'contact_id' => $contactId,
+      'financial_type_id' => "Donation",
+      'total_amount' => $amount,
+      'receive_date' => '2023-06-01',
+    // This creates a non payment financial transaction.
+      'is_pay_later' => TRUE,
+    ]);
+
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => $order['id'],
+      'total_amount' => $amount,
+      'trxn_date' => '2023-06-01',
+      'payment_instrument_id' => 'Credit Card',
+    //Test Payment Processor
+      'payment_processor' => 1,
+    ]);
+
+    $financialTrxnIds = civicrm_api3('FinancialTrxn', 'get', [
+      'sequential' => 1,
+      'options' => ['sort' => 'id desc'],
+    ])['values'];
+
+    $randomName = 'test_' . substr(md5(mt_rand()), 0, 5);
+    $batchId = civicrm_api3('Batch', 'create', [
+      'title' => $randomName,
+      'name' => $randomName,
+      'status_id' => 'Open',
+    ])['id'];
+
+    foreach ($financialTrxnIds as $fTrxn) {
+      civicrm_api3('EntityBatch', 'create', [
+        'entity_id' => $fTrxn['id'],
+        'batch_id' => $batchId,
+        'entity_table' => 'civicrm_financial_trxn',
+      ]);
+    }
+
+    return [
+      'contact_id' => $contactId,
+      'contact_name' => $contact['values'][$contactId]['display_name'],
+      'contribution_id' => $order['id'],
+      'batch_id' => $batchId,
+    ];
+  }
+
+  /**
+   * This function helps to mock Sale Tax financial account
+   * for simulating the financial tax for given financial type.
+   *
+   * @param int $taxRate
+   * @param string $financialTypeName
+   *
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockSalesTaxFinancialAccount($taxRate = 20, $financialTypeName = 'Donation') {
+    $existingRecordResponse = civicrm_api3('FinancialAccount', 'get', [
+      'sequential' => 1,
+      'options' => ['limit' => 1],
+      'name' => 'Sales Tax',
+    ]);
+
+    if (empty($existingRecordResponse['id'])) {
+      $financialAccount = civicrm_api3('FinancialAccount', 'create', [
+        'name' => 'Sales Tax',
+        'contact_id' => 1,
+        'financial_account_type_id' => 'Liability',
+        'accounting_code' => 5500,
+        'is_header_account' => 0,
+        'is_deductible' => TRUE,
+        'is_tax' => TRUE,
+        'tax_rate' => $taxRate,
+        'is_active' => TRUE,
+        'is_default' => 0,
+      ]);
+
+      civicrm_api3('EntityFinancialAccount', 'create', [
+        'entity_table' => 'civicrm_financial_type',
+        'account_relationship' => 'Sales Tax Account is',
+        'financial_account_id' => $financialAccount['id'],
+        'entity_id' => $this->getFinancialTypeID($financialTypeName),
+      ]);
+    }
+  }
+
+  /**
+   * Gets financial type ID from given financial type name.
+   *
+   * @param $financialTypeName
+   *
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  protected function getFinancialTypeID($financialTypeName) {
+    $financialType = civicrm_api3('FinancialType', 'get', [
+      'name' => $financialTypeName,
+      'sequential' => 1,
+    ]);
+
+    if ($financialType['count'] == 0) {
+      return CRM_MembershipExtras_Test_Fabricator_FinancialType::fabricate([
+        'sequential' => 1,
+        'name' => $financialTypeName,
+      ])['id'];
+    }
+
+    return $financialType['values'][0]['id'];
+  }
+
+  private function getContributionByID($id) {
+    return civicrm_api3('Contribution', 'getsingle', [
+      'id' => $id,
+    ]);
+  }
+
+  private function getLineItemByContributionID($id) {
+    return civicrm_api3('LineItem', 'getsingle', [
+      'entity_table' => "civicrm_contribution",
+      'contribution_id' => $id,
+    ]);
+  }
+
+}

--- a/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
@@ -7,7 +7,7 @@ use CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider as Sage50CSVPr
  */
 class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends BaseHeadlessTest {
 
-  public function setup() {
+  public function setup(): void {
     $this->setContributionSettings();
   }
 


### PR DESCRIPTION
## Overview

This PR handles the financial item lines for Sage50 export batch. 

The PR also updates minimum support to CiviCRM 5.51.3and update phpunit test to version 9

## Before

~ 

## After

Financial items lines are export as Sage50 format 

## Technical Details

* This PR is the first one that implements the logic, including batch queries. The query was copied and modified from the [CiviCRM core CSV export.](https://github.com/compucorp/civicrm-core/blob/master/CRM/Financial/BAO/ExportFormat/CSV.php#L65-L107). 
* The Sage50 format requires different output from the normal CiviCRM Journal entries. Therefore, logic was added to format the results based on the CiviCRM financial entity. In this pull request (PR), we only focus on the "non-payment" financial transactions, and any other records will not be exported.
See example, of the export file below. 

_Example without VAT._ 

```
|Type|Account Reference            |Nominal A/C Ref|Department Code                              |Date      |Reference|Details                           |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------------------|---------------|---------------------------------------------|----------|---------|----------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM                      |4100           |                                             |23/06/2023|INV_314  |Corwin Group - Contribution Amount|66.00     |T2      |0.00      |             |660            |         |            |              |
```

_Example with VAT._ 

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                           |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|200.00    |T1      |40.00     |             |649            |         |            |              |
|SI  |CiviCRM          |9000           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|40.00     |T1      |40.00     |             |649            |         |            |              |

```
* The tax code was one of the many challenges in producing the Sage50 export file. The tax code is determined by the line_item_financial_type_id, which is linked to the financial item. Therefore, it requires a separate function and queries to obtain it correctly. I implemented [caching](https://github.com/compucorp/io.compuco.financeexportformats/pull/6/commits/ba8f87dbc273e1bc30aad775dc94e89cb7652742#diff-c0fe486f31fbb6d2305124faa1fbf8105d59364a1a206be356dcbfcda809521eR147) of the tax code, as the value is always set in the financial account. This means we do not need to fetch the value from the database for every line.

## Comments

In the specification, the tax amount was designed to utilize the contribution line item tax amount. However, the line item tax amount will always change when using the line item editor to modify the value. This situation will necessitate a discussion with the product manager.

Here is an example of a transaction where the amount was altered from 200 to 100. Consequently, the tax amount originally set at 40 was subsequently adjusted to 20.

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                           |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|200.00    |T1      |20.00     |             |649            |         |            |              |
|SI  |CiviCRM          |9000           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|40.00     |T1      |20.00     |             |649            |         |            |              |
|SC  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|-100.00   |T1      |20.00     |             |657            |         |            |              |
|SC  |CiviCRM          |9000           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|-20.00    |T1      |20.00     |             |657            |         |            |              |

```