### PR TITLE
FOSFAB-177: Remove tax line items

### DIFF
--- a/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
@@ -72,6 +72,19 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
     $this->assertEquals('SC', $row[Sage50CSVProvider::TYPE_LABEL]);
   }
 
+  public function testRemoveTaxLineItems() {
+    $this->mockSalesTaxFinancialAccount();
+    $contributionData = $this->mockContributionInBatch(120);
+
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+
+    $this->assertEquals(2, count($queryResults));
+    $this->assertEquals(1, count($rows));
+  }
+
   /**
    * Sets CiviContribute settings.
    */


### PR DESCRIPTION
## Overview

This PR removes tax lines items from the export items. 

## Before

Tax line items always included in the export items. 

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                           |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|200.00    |T1      |20.00     |             |649            |         |            |              |
|SI  |CiviCRM          |9000           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|40.00     |T1      |20.00     |             |649            |         |            |              |
|SC  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|-100.00   |T1      |20.00     |             |657            |         |            |              |
|SC  |CiviCRM          |9000           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|-20.00    |T1      |20.00     |             |657            |         |            |              |
```

## After

Tax line items removed from the export items. 

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                           |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|200.00    |T1      |20.00     |             |649            |         |            |              |
|SC  |CiviCRM          |4300           |               |21/06/2023|INV_313  |Test Tax man - Contribution Amount|-100.00   |T1      |20.00     |             |657            |         |            |              |
```

## Technical Details

To remove tax line items from the report, we need to determine if the line item is a tax line item.  In order to do that, the account code is used to check if the financial account is configured as a tax account. In the logic, I also [cached ](https://github.com/compucorp/io.compuco.financeexportformats/compare/FOSFAB-27-workstream...FOSFAB-177-remove-tax-lines?expand=1#diff-c0fe486f31fbb6d2305124faa1fbf8105d59364a1a206be356dcbfcda809521eR186) to avoid fetching information from the CiviCRM API. 