### PR TITLE
FOSFAB-179: Format fee line items

### DIFF
--- a/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
@@ -5,7 +5,7 @@ use CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider as Sage50CSVPr
 /**
  * @group headless
  */
-class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends BaseHeadlessTest {
+class Sage50CSVProviderTest extends BaseHeadlessTest {
 
   public function setup(): void {
     $this->setContributionSettings();
@@ -85,7 +85,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
   }
 
   public function testPaymentProcessorLine() {
-    $contributionData = $this->mockContributionInBatch(100, TRUE);
+    $contributionData = $this->mockContributionInBatch(100, TRUE, TRUE);
     $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
     $provider = new Sage50CSVProvider();
 
@@ -111,7 +111,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
   }
 
   public function testPaymentProcessorRefundLine() {
-    $contributionData = $this->mockContributionInBatch(100, TRUE);
+    $contributionData = $this->mockContributionInBatch(100, TRUE, TRUE);
     $this->mockRefundPaymentTransaction($contributionData);
 
     $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
@@ -136,6 +136,62 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
     $row = $rows[1];
 
     $this->assertEquals($queryResult['payment_method'] . ' - ' . $queryResult['trxn_id'], $row[Sage50CSVProvider::DETAILS_LABEL]);
+  }
+
+  public function testPaymentProcessorFeeLine() {
+    $contributionData = $this->mockContributionInBatch(120, FALSE);
+    $result = $this->createTestPaymentProcessor();
+
+    civicrm_api3('contribution', 'completetransaction', [
+      'id' => $contributionData['contribution_id'],
+      'total_amount' => 100,
+      'trxn_id' => 'ch_xyz',
+      'payment_processor_id' => $result['id'],
+      'is_transactional' => FALSE,
+      'fee_amount' => 10 ?? NULL,
+      'card_type_id' => NULL,
+      'pan_truncation' => NULL,
+      'is_email_receipt' => FALSE,
+    ]);
+
+    $this->assignFinancialTransactionToExistingBatch($contributionData['batch_id']);
+
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+    $queryResult = $queryResults[4];
+    $row = $rows[4];
+    $this->assertEquals('SC', $row[Sage50CSVProvider::TYPE_LABEL]);
+    $this->assertEquals($queryResult['net_amount'], $row[Sage50CSVProvider::NET_AMOUNT_LABEL]);
+    $this->assertEquals($queryResult['payment_processor_name'] . ' Transaction Fee - ' . $queryResult['trxn_id'], $row[Sage50CSVProvider::DETAILS_LABEL]);
+  }
+
+  public function testManuallyAddFeeLine() {
+    $contributionData = $this->mockContributionInBatch(120, FALSE);
+
+    civicrm_api3('contribution', 'completetransaction', [
+      'id' => $contributionData['contribution_id'],
+      'total_amount' => 100,
+      'trxn_id' => 'ch_xyz',
+      'is_transactional' => FALSE,
+      'fee_amount' => 10 ?? NULL,
+      'card_type_id' => NULL,
+      'pan_truncation' => NULL,
+      'is_email_receipt' => FALSE,
+    ]);
+
+    $this->assignFinancialTransactionToExistingBatch($contributionData['batch_id']);
+    $exportResultDao = Sage50CSVProvider::runExportQuery($contributionData['batch_id']);
+    $provider = new Sage50CSVProvider();
+
+    list($queryResults, $rows) = $provider->formatDataRows($exportResultDao);
+    $queryResult = $queryResults[2];
+    $row = $rows[2];
+
+    $this->assertEquals('SC', $row[Sage50CSVProvider::TYPE_LABEL]);
+    $this->assertEquals($queryResult['net_amount'], $row[Sage50CSVProvider::NET_AMOUNT_LABEL]);
+    $this->assertEquals($queryResult['payment_method'] . ' Transaction Fee - ' . $queryResult['trxn_id'], $row[Sage50CSVProvider::DETAILS_LABEL]);
   }
 
   /**
@@ -203,11 +259,15 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
       'payment_instrument_id' => 'Credit Card',
     ]);
 
+    $this->assignFinancialTransactionToExistingBatch($contributionData['batch_id']);
+  }
+
+  private function assignFinancialTransactionToExistingBatch($batchID) {
     $entityBatch = civicrm_api3('EntityBatch', 'get', [
       'sequential' => 1,
       'return' => ["entity_id"],
       'entity_table' => "civicrm_financial_trxn",
-      'batch_id' => $contributionData['batch_id'],
+      'batch_id' => $batchID,
     ])['values'];
 
     $entityMap = [];
@@ -226,7 +286,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
       }
       civicrm_api3('EntityBatch', 'create', [
         'entity_id' => $fTrxn['id'],
-        'batch_id' => $contributionData['batch_id'],
+        'batch_id' => $batchID,
         'entity_table' => 'civicrm_financial_trxn',
       ]);
     }
@@ -238,7 +298,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
    *
    * @return array
    */
-  private function mockContributionInBatch($amount, $shouldPayWithPaymentProcessor = FALSE) {
+  private function mockContributionInBatch($amount, $shouldCreatePayment = TRUE, $shouldPayWithPaymentProcessor = FALSE) {
     $contact = civicrm_api3('Contact', 'create', [
       'contact_type' => 'Individual',
       'first_name' => 'John',
@@ -255,48 +315,27 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
       'is_pay_later' => TRUE,
     ]);
 
-    $paymentParams = [
-      'contribution_id' => $order['id'],
-      'total_amount' => $amount,
-      'trxn_date' => '2023-06-01',
-      'payment_instrument_id' => 'Credit Card',
-      'trxn_id' => 'trxn_123',
-    ];
+    if ($shouldCreatePayment) {
+      $paymentParams = [
+        'contribution_id' => $order['id'],
+        'total_amount' => $amount,
+        'trxn_date' => '2023-06-01',
+        'payment_instrument_id' => 'Credit Card',
+        'trxn_id' => 'trxn_123',
+      ];
 
-    if ($shouldPayWithPaymentProcessor) {
-      $result = civicrm_api3('PaymentProcessor', 'create', [
-        'payment_processor_type_id' => "Dummy",
-        'financial_account_id' => "Payment Processor Account",
-        'payment_instrument_id' => "Credit Card",
-        'is_active' => 1,
-        'name' => "Test Payment Processor",
-      ]);
+      if ($shouldPayWithPaymentProcessor) {
+        $result = $this->createTestPaymentProcessor();
 
-      $paymentParams['payment_processor_id'] = $result['id'];
-      $paymentParams['trxn_id'] = 'ch_xyz';
+        $paymentParams['payment_processor_id'] = $result['id'];
+        $paymentParams['trxn_id'] = 'ch_xyz';
+      }
+
+      civicrm_api3('Payment', 'create', $paymentParams);
     }
 
-    civicrm_api3('Payment', 'create', $paymentParams);
-
-    $financialTrxnIds = civicrm_api3('FinancialTrxn', 'get', [
-      'sequential' => 1,
-      'options' => ['sort' => 'id desc'],
-    ])['values'];
-
-    $randomName = 'test_' . substr(md5(mt_rand()), 0, 5);
-    $batchId = civicrm_api3('Batch', 'create', [
-      'title' => $randomName,
-      'name' => $randomName,
-      'status_id' => 'Open',
-    ])['id'];
-
-    foreach ($financialTrxnIds as $fTrxn) {
-      civicrm_api3('EntityBatch', 'create', [
-        'entity_id' => $fTrxn['id'],
-        'batch_id' => $batchId,
-        'entity_table' => 'civicrm_financial_trxn',
-      ]);
-    }
+    $batchId = $this->createBatch();
+    $this->assignFinancialTransactionToExistingBatch($batchId);
 
     return [
       'contact_id' => $contactId,
@@ -304,6 +343,16 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
       'contribution_id' => $order['id'],
       'batch_id' => $batchId,
     ];
+  }
+
+  private function createBatch() {
+    $randomName = 'test_' . substr(md5(mt_rand()), 0, 5);
+
+    return civicrm_api3('Batch', 'create', [
+      'title' => $randomName,
+      'name' => $randomName,
+      'status_id' => 'Open',
+    ])['id'];
   }
 
   /**
@@ -379,6 +428,16 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProviderTest extends 
     return civicrm_api3('LineItem', 'getsingle', [
       'entity_table' => "civicrm_contribution",
       'contribution_id' => $id,
+    ]);
+  }
+
+  private function createTestPaymentProcessor() {
+    return civicrm_api3('PaymentProcessor', 'create', [
+      'payment_processor_type_id' => "Dummy",
+      'financial_account_id' => "Payment Processor Account",
+      'payment_instrument_id' => "Credit Card",
+      'is_active' => 1,
+      'name' => "Test Payment Processor",
     ]);
   }
 


### PR DESCRIPTION
## Overview

This PR adds fee line items to Sage50 format.  

## Before

~

## After

Transaction fee shows in the 3rd line below. 

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                                             |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4200           |               |29/06/2023|INV_317  |Pierre Jore - Contribution Amount                   |300.00    |T2      |0.00      |             |678            |         |            |              |
|SA  |CiviCRM          |1150           |               |29/06/2023|INV_317  |Stripe - ch_3NOGmpQSeopny84z0aCh32QA                |300.00    |BANK    |0.00      |             |679            |         |            |              |
|SC  |CiviCRM          |5200           |               |29/06/2023|INV_317  |Stripe Transaction Fee - ch_3NOGmpQSeopny84z0aCh32QA|9.95      |EXP     |          |             |682            |         |            |              |

```
## Technical Details

There is a known issue that CiviCRM inconsistent recording of fee amount line items. If the form or payment uses `Payment.create `API to complete a transaction, the fee amount line items will not be created. 

In order to test if the line item is formatted correct for both payment processor and manual added fee, I use `Contribution.completetransaction` to mock a complete transaction, so fee amount line items are created.
