### PR TITLE
FOSFAB-192: Display negative amount correctly on payment line item.

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -160,7 +160,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
   }
 
   private function formatPaymentItemLines(array $item, $exportResultDao) {
-    if ($exportResultDao->amount >= 0) {
+    if ($exportResultDao->debit_total_amount >= 0) {
       $item[self::TYPE_LABEL] = 'SA';
     }
     else {


### PR DESCRIPTION
## Overview

This PR ensures that the type is generated correctly in the payment line item for negative transactions, specifically refunds that include a tax amount.

## Before

Type was set as SA for negative amount for transaction that includes tax. 

## After

Type is set to SP for the negative amount for transaction that includes tax.   

See row no 4. 
```

|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                                             |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |17/07/2023|INV_327  |Zieme, Parker and Senger - Contribution Amount      |777.00    |T1      |155.40    |             |780            |         |            |              |
|SA  |CiviCRM          |1150           |               |17/07/2023|INV_327  |Stripe - ch_3NUtJHQSeopny84z17TpL84D                |932.40    |BANK    |155.40    |             |781            |         |            |              |
|SC  |CiviCRM          |5200           |               |17/07/2023|INV_327  |Stripe Transaction Fee - ch_3NUtJHQSeopny84z17TpL84D|30.50     |EXP     |          |             |786            |         |            |              |
|SP  |CiviCRM          |1150           |               |17/07/2023|INV_327  |Credit Card - re_3NUtJHQSeopny84z18qhKXUA           |-23.00    |BANK    |155.40    |             |788            |         |            |              |

```
## Technical Details

During the formatting of payment line items for Sage50 format, we determine the type to be either SA or SP based on the transaction amount, whether it is negative or positive.

The amount field is generated from the queries, and we use the amount from the civicrm_entity_financial_trxn table. This ensures that it records as a positive amount on the refund line, which is separated from the sales tax. You can see this in the Journal report in the `Debit amount (split)` column below.
```

|Batch ID|Invoice No|Contact ID|Financial Trxn ID/Internal ID|Transaction Date   |Debit Account|Debit Account Name       |Debit Account Type|Debit Account Amount (Unsplit)|Transaction ID (Unsplit)|Debit amount (Split)|Payment Instrument|Check Number|Source                                          |Currency|Transaction Status|Amount|Credit Account|Credit Account Name      |Credit Account Type|Item Description   |
|--------|----------|----------|-----------------------------|-------------------|-------------|-------------------------|------------------|------------------------------|------------------------|--------------------|------------------|------------|------------------------------------------------|--------|------------------|------|--------------|-------------------------|-------------------|-------------------|
|9       |INV_138   |207       |206                          |2023-07-17 14:15:00|1150         |Payment Processor Account|BANK              |-40.00                        |RN_123                  |6.67                |Credit Card       |            |Submit Credit Card Payment by: admin@example.com|USD     |Refunded          |6.67  |1200          |Accounts Receivable      |AR                 |Contribution Amount|
|9       |INV_138   |207       |206                          |2023-07-17 14:15:00|1150         |Payment Processor Account|BANK              |-40.00                        |RN_123                  |-6.67               |Credit Card       |            |Submit Credit Card Payment by: admin@example.com|USD     |Refunded          |-6.67 |1200          |Accounts Receivable      |AR                 |Sales Tax          |
|9       |INV_138   |207       |207                          |2023-07-17 14:15:00|1150         |Payment Processor Account|BANK              |-30.00                        |EFT_123                 |30.00               |EFT               |            |Submit Credit Card Payment by: admin@example.com|USD     |Refunded          |30.00 |1200          |Accounts Receivable      |AR                 |Contribution Amount|
|9       |INV_138   |207       |207                          |2023-07-17 14:15:00|1150         |Payment Processor Account|BANK              |-30.00                        |EFT_123                 |-5.00               |EFT               |            |Submit Credit Card Payment by: admin@example.com|USD     |Refunded          |-5.00 |1200          |Accounts Receivable      |AR                 |Sales Tax          |
```

Since we display the debit total amount in the net amount for the payment line item, we only need to consider debit_total_amount as either a negative or positive amount. This allows us to assign the correct type to the line item.
