### PR TITLE
FOSFAB-191: Get tax amount from financial item, ignore tax lines in the query 

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -122,7 +122,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
       $taxFinanceAccountsCondition[] = $financialAccount['id'];
     };
 
-    // Edge case,support where there is not tax account.
+    // Edge case, support where there is no tax account.
     if (empty($taxFinanceAccountsCondition)) {
       $taxFinanceAccountsCondition[] = 0;
     }


### PR DESCRIPTION
## Overview

This PR updates how we get the tax amount on the financial lines. Previously, I decided to calculate the tax amount on the fly, which was introduced in this [PR](https://github.com/compucorp/io.compuco.financeexportformats/pull/12). 

The previous solution has a flaw because the calculation could be incorrect when the Government decides to change the tax rate and the Finance admin decides to update the tax rate in the existing sales tax account instead of creating a new one. As a result, we would use the incorrect tax rate to calculate the existing financial lines when exporting the report.

In order to get a tax amount from the financial item, we would need to left join with sub query to get a second `civicrm_financial_item` which is a sale tax item which links to the same financial transaction where the financial account is tax account. 

To illustrate how financial items links to financial transactions in CiviCRM. I attached the image below: 

![trxn](https://github.com/compucorp/io.compuco.financeexportformats/assets/208713/721e049f-ece0-487e-94d2-7347b7590310)

I also ensure that we only select a financial item from the non-payment transaction (we do not need to split tax amount for payment line), as CiviCRM could create multiple tax sale items (this is a core bug) when it tries to split the amount during the payment of a contribution, and line items are added or changed after the first payment has been completed.

Additional join that was added is below. 
```
 LEFT JOIN civicrm_financial_item fii ON (fii.id = (SELECT eftii.entity_id
       FROM civicrm_entity_financial_trxn eftii
       WHERE eftii.financial_trxn_id  = ft.id
       AND eftii.entity_table = 'civicrm_financial_item'
       AND eftii.entity_id <> fi.id and ft.is_payment = 0) AND (fii.financial_account_id IN ($taxAccounts)))      
```

In this PR, I also improve the logic in this [commit](https://github.com/compucorp/io.compuco.financeexportformats/pull/13/commits/6e9a96c0a96b82ecd3e783098faf534e2f788a9a ) to ignore the tax line item by adding a condition in the query to exclude tax lines, so we do not discard the tax lines in the result  which makes the result aligns with the actual rows in the batch. 

_Example of the batch export that include refund and line item amount changed_ 

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                                             |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |26/07/2023|INV_350  |Test2 Test2 - Contribution Amount                   |600.00    |T1      |120.00    |             |1057           |         |            |              |
|SA  |CiviCRM          |1150           |               |26/07/2023|INV_350  |Stripe - ch_3NY8uRQSeopny84z0xTLHyNl                |720.00    |T9      |          |             |1058           |         |            |              |
|SC  |CiviCRM          |5200           |               |26/07/2023|INV_350  |Stripe Transaction Fee - ch_3NY8uRQSeopny84z0xTLHyNl|23.60     |EXP     |          |             |1063           |         |            |              |
|SP  |CiviCRM          |1150           |               |26/07/2023|INV_350  |Credit Card - re_3NY8uRQSeopny84z0hZAWm35           |-333.00   |T9      |          |             |1065           |         |            |              |
|SC  |CiviCRM          |4300           |               |26/07/2023|INV_350  |Test2 Test2 - Contribution Amount                   |-300.00   |T1      |-60.00    |             |1068           |         |            |              |
```

_Here is an example of a batch export for a transaction that was initially paid, then the line item was edited to increase the amount, and the remaining balance was paid._

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                                             |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|----------------------------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |26/07/2023|INV_349  |Test real Real 2 - Contribution Amount              |100.00    |T1      |20.00     |             |1044           |         |            |              |
|SA  |CiviCRM          |1150           |               |26/07/2023|INV_349  |Stripe - ch_3NY7CCQSeopny84z16z0bcYT                |120.00    |T9      |          |             |1047           |         |            |              |
|SI  |CiviCRM          |4300           |               |26/07/2023|INV_349  |Test real Real 2 - Contribution Amount              |100.00    |T1      |20.00     |             |1050           |         |            |              |
|SA  |CiviCRM          |1150           |               |26/07/2023|INV_349  |Stripe - ch_3NY7D9QSeopny84z1mxAJkXf                |120.00    |T9      |          |             |1053           |         |            |              |
```
## Comments

There is still ongoing issue with civibuild that we use to build the site for running unit testing on Github action and it yet to be fixed.  After the changes, the unit tests were run locally and it passed testing as below. 

```
devilbox@php:/var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/io.compuco.financeexportformats$ phpunit5
[26-Jul-2023 16:18:05 UTC] PHP Warning:  Private methods cannot be final as they are never overridden by other classes in phar:///opt/buildkit/extern/phpunit5/phpunit5.phar/phpunit/Util/Configuration.php on line 162
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

....................                                              20 / 20 (100%)

Time: 19.01 seconds, Memory: 70.50MB

OK (20 tests, 58 assertions)
devilbox@php:/var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/io.compuco.financeexportformats$
```