### PR TITLE
FOSFAB-181: Make amount and tax mount negative for refunded/cancelled transaction

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -234,7 +234,17 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
       return NULL;
     }
 
-    if ($exportResultDao->amount >= 0) {
+    $shouldMakeNumberNegative = $exportResultDao->debit_total_amount < 0 && $exportResultDao->net_amount >= 0;
+    if ($shouldMakeNumberNegative) {
+      $netAmount = -$exportResultDao->net_amount;
+      $taxAmount = -$exportResultDao->tax_amount;
+    }
+    else {
+      $netAmount = $exportResultDao->net_amount;
+      $taxAmount = $exportResultDao->tax_amount;
+    }
+
+    if ($netAmount >= 0) {
       $item[self::TYPE_LABEL] = 'SI';
     }
     else {
@@ -243,9 +253,9 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
 
     $item[self::NOMINAL_AC_REF_LABEL] = $exportResultDao->from_credit_account;
     $item[self::DETAILS_LABEL] = $exportResultDao->contact_display_name . ' - ' . $exportResultDao->item_description;
-    $item[self::NET_AMOUNT_LABEL] = $exportResultDao->net_amount;
+    $item[self::NET_AMOUNT_LABEL] = $netAmount;
     $item[self::TAX_CODE_LABEL] = $this->getFinancialIemLinesTaxCodeByFinancialID($exportResultDao->financial_type_id);
-    $item[self::TAX_AMOUNT_LABEL] = $exportResultDao->tax_amount;
+    $item[self::TAX_AMOUNT_LABEL] = $taxAmount;
 
     return $item;
   }


### PR DESCRIPTION
## Overview

This PR ensures that the sage50 export report works with civicrm entities with CiviCRM patch from this core PR https://github.com/civicrm/civicrm-core/pull/26982

With above PR, Civi will record split transactions, which is similar to how Civi records the payment transaction where debit amount (unspliced) is negative, but split amount remain positive. (look at the example in above PR) 

So this PR, update the financial line logic to support above case on `Cr Income / Dr Receivable -amount `transaction.

## Before

Example of transactions that changed from Completed to Cancelled and line two, show was positive amount which is duplicated to line 1
```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                  |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|-------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4400           |               |04/08/2023|         |D D - Contribution Amount|50.00     |T2      |5.00      |             |41             |         |Member Dues |              |
|SI  |CiviCRM          |4400           |               |04/08/2023|         |D D - Contribution Amount|50.00     |T2      |5.00      |             |45             |         |Member Dues |              |
|SP  |CiviCRM          |1100           |               |04/08/2023|         |Cheque -                 |-55.00    |BANK    |          |             |46             |         |Member Dues |              |

```
## After

Example of transactions that changed from Completed to Cancelled
```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                  |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|-------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4400           |               |04/08/2023|INV_386  |T T - Contribution Amount|100.00    |T10     |10.00     |             |1388           |         |Member Dues |              |
|SA  |CiviCRM          |1100           |               |04/08/2023|INV_386  |Cheque -                 |110.00    |BANK    |          |             |1389           |         |Member Dues |              |
|SC  |CiviCRM          |4400           |               |04/08/2023|INV_386  |T T - Contribution Amount|-100      |T10     |-10       |             |1392           |         |Member Dues |              |
|SP  |CiviCRM          |1100           |               |04/08/2023|INV_386  |Cheque -                 |-110.00   |BANK    |          |             |1393           |         |Member Dues |              |

```

Example of negative amount shows when use line item editor
```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                  |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|-------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4200           |               |04/08/2023|INV_388  |T T - Contribution Amount|200.00    |T2      |          |             |1405           |         |Donation    |              |
|SC  |CiviCRM          |4200           |               |04/08/2023|INV_388  |T T - Contribution Amount|-50.00    |T2      |          |             |1407           |         |Donation    |              |
|SA  |CiviCRM          |1100           |               |04/08/2023|INV_388  |Credit Card -            |150.00    |BANK    |          |             |1409           |         |Donation    |              |

```


## Technical Details

In the financial line, the net amount would be an amount - tax amount unlike the payment line, the amount would be total debit amount.  As I mentioned in the overview, Civi does not record an amount as negative amount despite that it negative transaction, we could just simply check if `debit_total_amount `less than zero then we put the net amount as negative. But this will not work with the transaction created by line item editor, where the financial item amount is set to negative. 

So, below logic to apply to negative amount to the positive amount are only for the line that `debit_total_amount `less than zero and `net_amount `is greater or equals zero. 

```
   $shouldMakeNumberNegative = $exportResultDao->debit_total_amount < 0 && $exportResultDao->net_amount >= 0;
    if ($shouldMakeNumberNegative) {
      $netAmount = -$exportResultDao->net_amount;
      $taxAmount = -$exportResultDao->tax_amount;
    }
    else {
      $netAmount = $exportResultDao->net_amount;
      $taxAmount = $exportResultDao->tax_amount;
    }
```
