### PR TITLE
FOSFAB-176: Make sure net amount and tax amount are always positive amount

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -234,28 +234,19 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
       return NULL;
     }
 
-    $shouldMakeNumberNegative = $exportResultDao->debit_total_amount < 0 && $exportResultDao->net_amount >= 0;
-    if ($shouldMakeNumberNegative) {
-      $netAmount = -$exportResultDao->net_amount;
-      $taxAmount = -$exportResultDao->tax_amount;
-    }
-    else {
-      $netAmount = $exportResultDao->net_amount;
-      $taxAmount = $exportResultDao->tax_amount;
-    }
-
-    if ($netAmount >= 0) {
-      $item[self::TYPE_LABEL] = 'SI';
-    }
-    else {
+    $shouldMakeTypeNegative = $exportResultDao->debit_total_amount < 0 && $exportResultDao->net_amount >= 0;
+    if ($shouldMakeTypeNegative || $exportResultDao->net_amount < 0) {
       $item[self::TYPE_LABEL] = 'SC';
+    }
+    else {
+      $item[self::TYPE_LABEL] = 'SI';
     }
 
     $item[self::NOMINAL_AC_REF_LABEL] = $exportResultDao->from_credit_account;
     $item[self::DETAILS_LABEL] = $exportResultDao->contact_display_name . ' - ' . $exportResultDao->item_description;
-    $item[self::NET_AMOUNT_LABEL] = $netAmount;
+    $item[self::NET_AMOUNT_LABEL] = abs($exportResultDao->net_amount);
     $item[self::TAX_CODE_LABEL] = $this->getFinancialIemLinesTaxCodeByFinancialID($exportResultDao->financial_type_id);
-    $item[self::TAX_AMOUNT_LABEL] = $taxAmount;
+    $item[self::TAX_AMOUNT_LABEL] = abs($exportResultDao->tax_amount);
 
     return $item;
   }

--- a/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
@@ -71,6 +71,8 @@ class Sage50CSVProviderTest extends BaseHeadlessTest {
     // Test row 1 here as row 2 is a payment line.
     $row = $rows[1];
     $this->assertEquals('SC', $row[Sage50CSVProvider::TYPE_LABEL]);
+    $this->assertTrue($row[Sage50CSVProvider::NET_AMOUNT_LABEL] >= 0);
+    $this->assertTrue($row[Sage50CSVProvider::TAX_AMOUNT_LABEL] >= 0);
   }
 
   public function testPaymentProcessorLine() {


### PR DESCRIPTION
## Overview

This PR fixes the issue where the net amount and tax amount in financial line item with negative amount did not get generated as positive amount. This covers a couple of two scenarios: 

1. A financial line item that created as negative because of line item editor where both `debit_total_amount `and `net_amount ` are negative. 
2. A financial line item that created as negative from the split transaction when changing a contribution status from completed to cancelled or refunded, where  `debit_total_amount ` is negative and `net_amount  `is positive. 

This means that net amount will always positive regardless if the line is negative line. Sage50 will know if this is negative line from the type `SC`.
. 
## Before

Example of transactions that changed from Completed to Cancelled show negative amount with `SC` type on row 3,
```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                  |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|-------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4400           |               |04/08/2023|INV_386  |T T - Contribution Amount|100.00    |T10     |10.00     |             |1388           |         |Member Dues |              |
|SA  |CiviCRM          |1100           |               |04/08/2023|INV_386  |Cheque -                 |110.00    |BANK    |          |             |1389           |         |Member Dues |              |
|SC  |CiviCRM          |4400           |               |04/08/2023|INV_386  |T T - Contribution Amount|-100      |T10     |-10       |             |1392           |         |Member Dues |              |
|SP  |CiviCRM          |1100           |               |04/08/2023|INV_386  |Cheque -                 |-110.00   |BANK    |          |             |1393           |         |Member Dues |              |

```

Example of negative amount shows when use line item editor with `SC `type on row 2
```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                  |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|-------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4200           |               |04/08/2023|INV_388  |T T - Contribution Amount|200.00    |T2      |          |             |1405           |         |Donation    |              |
|SC  |CiviCRM          |4200           |               |04/08/2023|INV_388  |T T - Contribution Amount|-50.00    |T2      |          |             |1407           |         |Donation    |              |
|SA  |CiviCRM          |1100           |               |04/08/2023|INV_388  |Credit Card -            |150.00    |BANK    |          |             |1409           |         |Donation    |              |

```

## After

Negative transaction created by changing status from completed to cancelled or refunded. The row type `SC `shows positive net amount and tax amount on row 3

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                             |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|------------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |10/08/2023|INV_395  |Leandra Allsup - Contribution Amount|500       |T1      |100       |             |1450           |         |Event Fee   |              |
|SA  |CiviCRM          |1100           |               |10/08/2023|INV_395  |Cheque -                            |600.00    |BANK    |          |             |1451           |         |Event Fee   |              |
|SC  |CiviCRM          |4300           |               |10/08/2023|INV_395  |Leandra Allsup - Contribution Amount|500       |T1      |100       |             |1454           |         |Event Fee   |              |
|SP  |CiviCRM          |1100           |               |10/08/2023|INV_395  |Cheque -                            |-600.00   |BANK    |          |             |1455           |         |Event Fee   |              |

```

Negative transaction created by line item editor, row `SC `type row shows positive amount on row 2 

```
|Type|Account Reference|Nominal A/C Ref|Department Code|Date      |Reference|Details                             |Net Amount|Tax Code|Tax Amount|Exchange Rate|Extra Reference|User Name|Project Refn|Cost Code Refn|
|----|-----------------|---------------|---------------|----------|---------|------------------------------------|----------|--------|----------|-------------|---------------|---------|------------|--------------|
|SI  |CiviCRM          |4300           |               |10/08/2023|INV_394  |Leandra Allsup - Contribution Amount|100       |T1      |20        |             |1440           |         |Event Fee   |              |
|SC  |CiviCRM          |4300           |               |10/08/2023|INV_394  |Leandra Allsup - Contribution Amount|50        |T1      |10        |             |1443           |         |Event Fee   |              |
|SA  |CiviCRM          |1100           |               |10/08/2023|INV_394  |Credit Card - TX56456               |60.00     |BANK    |          |             |1446           |         |Event Fee   |              |

```