### PR TITLE
COMCL-1035: Fix Sage50 Report

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -78,7 +78,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
         WHEN li.financial_type_id IS NOT NULL
         THEN li.financial_type_id
         ELSE fcli.financial_type_id
-      END" : "li.financial_type_id") . " as financial_type_id,     
+      END" : "li.financial_type_id") . " as financial_type_id,
       fty.name as financial_type,
       ftyc.name as contribution_financial_type,
       ov.label as department_code
@@ -102,7 +102,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
                                                      AND eftii.entity_id <> fi.id
                                                      AND fiii.financial_account_id IN ($taxAccounts)
                                                      AND ft.is_payment = 0
-                                                     AND fi.entity_id = fiii.entity_id)
+                                                     AND fi.entity_id = fiii.entity_id ORDER BY fiii.id DESC LIMIT 1)
                                                 AND (fii.financial_account_id IN ($taxAccounts)))
              LEFT JOIN civicrm_line_item li ON (li.id = fi.entity_id AND fi.entity_table = 'civicrm_line_item')
              " . ($supportCreditNote ? "LEFT JOIN financeextras_credit_note_line fcli ON (fcli.id = fi.entity_id AND fi.entity_table = 'financeextras_credit_note_line')" : "") . "


### PR DESCRIPTION
## Overview
This pr fixes a bug that restricted users from accessing sage50 report.

## Before
The user was shown an error upon downloading the report as the query for the sage50 report was failing with an error that **sub query returned more than one row**.

## After
The report is downloading successfully

## Technical Details
The issue was that the query expected there to be just one financial item record for tax for a payment but in a scenario where a membership gets created with a pending payment and later on its paid through an online contribution page all the financial item gets duplicated and for this scenario there exists two identical tax financial item records. So this pr fixes it by choosing the latest record.
