### PR TITLE
CIVIMM-351: Change Tax Amount Column In Sage50 Report

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -171,7 +171,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
         self::DETAILS_LABEL => NULL,
         self::NET_AMOUNT_LABEL => NULL,
         self::TAX_CODE_LABEL => NULL,
-        self::TAX_AMOUNT_LABEL => NULL,
+        self::TAX_AMOUNT_LABEL => 0,
         self::EXCHANGE_RATE_LABEL => NULL,
         self::EXTRA_REFERENCE => $exportResultDao->civicrm_entity_financial_trxn_id,
         self::USER_NAME_LABEL => NULL,
@@ -196,6 +196,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
         }
       }
 
+      $formattedItem[self::TAX_AMOUNT_LABEL] = number_format((float) $formattedItem[self::TAX_AMOUNT_LABEL], 2, '.', '');
       $financialItems[] = $formattedItem;
       end($financialItems);
     }


### PR DESCRIPTION
## Overview
This PR changes the tax amount column in sage50 report to appear as 0.00 instead of blank for transactions where there is no tax amount.

## Before
[before.csv](https://github.com/user-attachments/files/21035474/before.csv)


## After
[after.csv](https://github.com/user-attachments/files/21035476/after.csv)

