### PR TITLE
CIVIMM-354: Always Display Positive Amount For Payment Lines

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
+++ b/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProvider.php
@@ -230,7 +230,7 @@ class CRM_Financial_BAO_ExportFormat_DataProvider_Sage50CSVProvider {
     $item[self::NOMINAL_AC_REF_LABEL] = $exportResultDao->to_account_code;
     $paymentMethod = is_null($exportResultDao->payment_processor_id) ? $exportResultDao->payment_method : $exportResultDao->payment_processor_name;
     $item[self::DETAILS_LABEL] = "$paymentMethod - $exportResultDao->trxn_id";
-    $item[self::NET_AMOUNT_LABEL] = $exportResultDao->debit_total_amount;
+    $item[self::NET_AMOUNT_LABEL] = abs($exportResultDao->debit_total_amount);
     $item[self::TAX_CODE_LABEL] = $exportResultDao->to_account_type_code;
 
     $this->paymentLineMap[$exportResultDao->civicrm_entity_financial_trxn_id] = TRUE;

--- a/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/ExportFormat/DataProvider/Sage50CSVProviderTest.php
@@ -114,7 +114,7 @@ class Sage50CSVProviderTest extends BaseHeadlessTest {
     $row = $rows[2];
     $this->assertEquals('SP', $row[Sage50CSVProvider::TYPE_LABEL]);
     $this->assertEquals($queryResult['payment_processor_name'] . ' - ' . $queryResult['trxn_id'], $row[Sage50CSVProvider::DETAILS_LABEL]);
-    $this->assertEquals(-50, $row[Sage50CSVProvider::NET_AMOUNT_LABEL]);
+    $this->assertEquals(50, $row[Sage50CSVProvider::NET_AMOUNT_LABEL]);
   }
 
   public function testManuallyAddedPaymentLine() {


### PR DESCRIPTION
## Overview
This PR displays the net amount as a positive value for all the payment line items always even for refund as well. This change is needed as sage50 report exports the rows in avery specific output and to denote negative amounts we have a separete column by the name of **Type** but the amount column for all payment rows should display a positive value.

## Before
The net amount for refund lines appear as negative
[before.csv](https://github.com/user-attachments/files/21056433/before.csv)


## After
The net amount is always positive
[after.csv](https://github.com/user-attachments/files/21056435/after.csv)
